### PR TITLE
bug: set max-width on img tags inside picture

### DIFF
--- a/src/components/image-responsive.vue
+++ b/src/components/image-responsive.vue
@@ -3,6 +3,13 @@
  * Displays a responsive picture tag
  */
 
+<style module>
+  .img {
+    height: auto;
+    max-width: 100%;
+  }
+</style>
+
 <script>
 import { imageUrl } from '../utility/fastly'
 import { sourceTagAttributes } from '../utility/html'
@@ -149,12 +156,6 @@ export default {
       })
     ])
   }
-}
+}; // eslint-disable-line semi
+// Needed to make Vue test utils and require-extension-hooks work correctly
 </script>
-
-<style module>
-  .img {
-    height: auto;
-    max-width: 100%;
-  }
-</style>

--- a/src/components/image-responsive.vue
+++ b/src/components/image-responsive.vue
@@ -144,9 +144,17 @@ export default {
         attrs: {
           alt: context.props.alt,
           src: imageUrl(domain, context.props.src, imgOptions)
-        }
+        },
+        class: context.$style.img
       })
     ])
   }
 }
 </script>
+
+<style module>
+  .img {
+    height: auto;
+    max-width: 100%;
+  }
+</style>

--- a/src/components/image-responsive.vue
+++ b/src/components/image-responsive.vue
@@ -152,7 +152,8 @@ export default {
           alt: context.props.alt,
           src: imageUrl(domain, context.props.src, imgOptions)
         },
-        class: context.$style.img
+        // During unit tests, we don't compile styles, so context.$style is null
+        class: (context.$style != null) ? context.$style.img : null
       })
     ])
   }

--- a/src/components/image.vue
+++ b/src/components/image.vue
@@ -141,9 +141,19 @@ export default {
     return h('img', Object.assign({}, context.data, {
       attrs: {
         alt: context.props.alt,
-        src: imageUrl(domain, context.props.src, fastlyOptions)
-      }
+        height: context.props.height,
+        src: imageUrl(domain, context.props.src, fastlyOptions),
+        width: context.props.width
+      },
+      class: context.$style.img
     }))
   }
 }
 </script>
+
+<style module>
+  .img {
+    height: auto;
+    max-width: 100%;
+  }
+</style>

--- a/src/components/image.vue
+++ b/src/components/image.vue
@@ -3,6 +3,13 @@
  * A basic img tag but with fastly API options as props.
  */
 
+<style module>
+  .img {
+    height: auto;
+    max-width: 100%;
+  }
+</style>
+
 <script>
 import { imageUrl } from '../utility/fastly'
 
@@ -148,12 +155,6 @@ export default {
       class: context.$style.img
     }))
   }
-}
+}; // eslint-disable-line semi
+// Needed to make Vue test utils and require-extension-hooks work correctly
 </script>
-
-<style module>
-  .img {
-    height: auto;
-    max-width: 100%;
-  }
-</style>

--- a/src/components/image.vue
+++ b/src/components/image.vue
@@ -152,7 +152,8 @@ export default {
         src: imageUrl(domain, context.props.src, fastlyOptions),
         width: context.props.width
       },
-      class: context.$style.img
+      // During unit tests, we don't compile styles, so context.$style is null
+      class: (context.$style != null) ? context.$style.img : null
     }))
   }
 }; // eslint-disable-line semi

--- a/src/components/product-thumbnail.vue
+++ b/src/components/product-thumbnail.vue
@@ -132,7 +132,8 @@ export default {
           alt: imageAlt,
           src: imageUrl(domain, path, fastlyOptions)
         },
-        class: context.$style.img
+        // During unit tests, we don't compile styles, so context.$style is null
+        class: (context.$style != null) ? context.$style.img : null
       })
     ])
   }

--- a/src/components/product-thumbnail.vue
+++ b/src/components/product-thumbnail.vue
@@ -3,6 +3,13 @@
  * Displays the small thumbnail for a product.
  */
 
+<style module>
+  .img {
+    height: auto;
+    max-width: 100%;
+  }
+</style>
+
 <script>
 import { imageUrl } from '../utility/fastly'
 
@@ -129,12 +136,6 @@ export default {
       })
     ])
   }
-}
+}; // eslint-disable-line semi
+// Needed to make Vue test utils and require-extension-hooks work correctly
 </script>
-
-<style module>
-  .img {
-    height: auto;
-    max-width: 100%;
-  }
-</style>

--- a/src/components/product-thumbnail.vue
+++ b/src/components/product-thumbnail.vue
@@ -124,9 +124,17 @@ export default {
         attrs: {
           alt: imageAlt,
           src: imageUrl(domain, path, fastlyOptions)
-        }
+        },
+        class: context.$style.img
       })
     ])
   }
 }
 </script>
+
+<style module>
+  .img {
+    height: auto;
+    max-width: 100%;
+  }
+</style>


### PR DESCRIPTION
This should fix the `img` tags growing outside their `parent` tag during load.